### PR TITLE
Fix osx arm64 build arch

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,4 +1,8 @@
-#!/bin/bash
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$PREFIX
+#!/bin/bash -e
+
+cmake ${CMAKE_ARGS} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=$PREFIX
+
 cmake --build . --config Release --target all
 cmake --build . --config Release --target install

--- a/recipe/cmake-osx-arch-arm64.patch
+++ b/recipe/cmake-osx-arch-arm64.patch
@@ -1,0 +1,12 @@
+diff -urN a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt	2018-04-23 23:05:42.000000000 +0300
++++ b/CMakeLists.txt	2022-01-21 17:13:39.380085910 +0300
+@@ -17,7 +17,7 @@
+ execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_SOURCE_DIR}/lib)
+ set(LIBRARY_OUTPUT_PATH ${CMAKE_SOURCE_DIR}/lib)
+ 
+-set(CMAKE_OSX_ARCHITECTURES x86_64)
++set(CMAKE_OSX_ARCHITECTURES arm64)
+ set(CMAKE_C_VISIBILITY_PRESET hidden)
+ set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
+ 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,9 @@ source:
   fn: libgpuarray-{{ version }}.tar.gz
   url: https://github.com/Theano/libgpuarray/releases/download/v{{ version }}/libgpuarray-{{ version }}.tar.gz
   sha256: 887b6433a30282cb002117da89b05812c770fd9469f93950ff3866ddd02bfc64
+  patches:
+    # Changes CMAKE_OSX_ARCHITECTURES from x86_64 to arm64
+    - cmake-osx-arch-arm64.patch  # [osx and arm64]
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ source:
   fn: libgpuarray-{{ version }}.tar.gz
   url: https://github.com/Theano/libgpuarray/releases/download/v{{ version }}/libgpuarray-{{ version }}.tar.gz
   sha256: 887b6433a30282cb002117da89b05812c770fd9469f93950ff3866ddd02bfc64
-  patches:
+  patches:  # [osx and arm64]
     # Changes CMAKE_OSX_ARCHITECTURES from x86_64 to arm64
     - cmake-osx-arch-arm64.patch  # [osx and arm64]
 


### PR DESCRIPTION
On osx-arm64 we were generating artifacts for x86_64. Add a patch explicitly setting the architecture to arm64. This is going to be uploaded only on osx-arm64 and to replace the defective package we have there at the moment.