### PR TITLE
Add missing build dependency on patch

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - {{ compiler('c') }}
     - cmake
     - make  # [unix]
+    - patch  # [osx and arm64]
   host:
     - mako
 


### PR DESCRIPTION
This version is already integrated, the PR only adds a build dependency on `patch` for correctness.